### PR TITLE
Allow check for RGBA32F

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -259,7 +259,7 @@ namespace bgfx { namespace gl
 			SKIP_ALL,//RGBA16S,
 			SKIP_ALL,//RGBA32I,
 			SKIP_ALL,//RGBA32U,
-			SKIP_ALL,//RGBA32F, 60
+            SKIP_MIP_AUTOGEN,//RGBA32F, 60
 			SKIP_ALL,//R5G6B5,
 			SKIP_ALL,//RGBA4,
 			SKIP_ALL,//RGB5A1,


### PR DESCRIPTION
Allow check for RGBA32F. We are going to skip just the mip autogen because opengl es 3.0 does not support that for RGBA32F