### PR TITLE
Don't cast max texture size into uint16

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2426,7 +2426,7 @@ namespace bgfx { namespace gl
 					: 0
 					;
 
-				g_caps.limits.maxTextureSize = uint16_t(glGet(GL_MAX_TEXTURE_SIZE) );
+				g_caps.limits.maxTextureSize = glGet(GL_MAX_TEXTURE_SIZE);
 
 				if (BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL)
 				||  BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGLES >= 30)


### PR DESCRIPTION
Casting big textures down to uint16 is going to cause overflow. There is no reason to cast here since we are saving these values as uint32.